### PR TITLE
web-basic ECS service module

### DIFF
--- a/tf/modules/services/base/web-basic/iam.tf
+++ b/tf/modules/services/base/web-basic/iam.tf
@@ -1,0 +1,48 @@
+########
+# ROLE #
+########
+
+resource "aws_iam_role" "service" {
+  name = "${var.name}-service-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "service" {
+  name = "${var.name}-service-role-policy"
+  role = "${aws_iam_role.service.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:Describe*",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:Describe*",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:RegisterTargets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/tf/modules/services/base/web-basic/main.tf
+++ b/tf/modules/services/base/web-basic/main.tf
@@ -106,8 +106,8 @@ resource "aws_route53_record" "service" {
   type    = "A"
 
   alias {
-    name                   = "${var.load_balancer_fqdn == "" ? join("", aws_alb.service.*.dns_name) : var.load_balancer_fqdn}"
-    zone_id                = "${var.load_balancer_zone_id == "" ? join("", aws_alb.service.*.zone_id) : var.load_balancer_zone_id}"
+    name                   = "${var.load_balancer_fqdn}"
+    zone_id                = "${var.load_balancer_zone_id}"
     evaluate_target_health = false
   }
 }

--- a/tf/modules/services/base/web-basic/main.tf
+++ b/tf/modules/services/base/web-basic/main.tf
@@ -1,0 +1,113 @@
+###############
+# ECS SERVICE #
+###############
+
+resource "aws_ecs_service" "service" {
+  name            = "${var.name}"
+  cluster         = "${var.cluster_id}"
+  task_definition = "${var.task_definition_arn}"
+  desired_count   = "${var.desired_count}"
+  iam_role        = "${aws_iam_role.service.id}"
+
+  health_check_grace_period_seconds = "${var.health_check_grace_period_seconds}"
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.service.arn}"
+    container_name   = "${var.container_name}"
+    container_port   = "${var.container_port}"
+  }
+
+  scheduling_strategy = "${var.scheduling_strategy}"
+
+  depends_on = [
+    "aws_iam_role_policy.service",
+  ]
+}
+
+####################
+# ALB TARGET GROUP #
+####################
+
+resource "aws_alb_target_group" "service" {
+  name                 = "${var.name}"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = "${var.vpc}"
+  deregistration_delay = "${var.deregistration_delay}"
+
+  health_check {
+    path                = "${var.health_check_path}"
+    timeout             = "${var.health_check_timeout}"
+    healthy_threshold   = "${var.health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+    interval            = "${var.health_check_interval}"
+    matcher             = "${var.health_check_matcher}"
+  }
+}
+
+resource "aws_alb_listener_rule" "http" {
+  count        = "${var.load_balancer_http_listener_arn == "" ? 0 : length(var.path_patterns)}"
+  listener_arn = "${var.load_balancer_http_listener_arn}"
+  priority     = "${var.service_number_http + count.index}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.service.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${var.hostname == "" ? "${var.domain}" : "${var.hostname}.${var.domain}"}"]
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${element(var.path_patterns, count.index)}"]
+  }
+
+  lifecycle {
+    ignore_changes = ["priority"]
+  }
+}
+
+resource "aws_alb_listener_rule" "https" {
+  count        = "${var.load_balancer_https_listener_arn == "" ? 0 : length(var.path_patterns)}"
+  listener_arn = "${var.load_balancer_https_listener_arn}"
+  priority     = "${var.service_number_https + count.index}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.service.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${var.hostname == "" ? "${var.domain}" : "${var.hostname}.${var.domain}"}"]
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${element(var.path_patterns, count.index)}"]
+  }
+
+  lifecycle {
+    ignore_changes = ["priority"]
+  }
+}
+
+#######
+# DNS #
+#######
+
+resource "aws_route53_record" "service" {
+  count   = "${var.hostname == "" ? 0 : 1}"
+  zone_id = "${var.zone_id}"
+  name    = "${var.hostname}.${var.domain}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.load_balancer_fqdn == "" ? join("", aws_alb.service.*.dns_name) : var.load_balancer_fqdn}"
+    zone_id                = "${var.load_balancer_zone_id == "" ? join("", aws_alb.service.*.zone_id) : var.load_balancer_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/tf/modules/services/base/web-basic/output.tf
+++ b/tf/modules/services/base/web-basic/output.tf
@@ -1,0 +1,14 @@
+output "url" {
+  description = "external url"
+  value       = "${var.hostname == "" ? "${var.domain}" : "${var.hostname}.${var.domain}"}"
+}
+
+output "target_group_arn" {
+  description = "ARN of ALB target group"
+  value       = "${aws_alb_target_group.service.arn}"
+}
+
+output "service_role_name" {
+  description = "Name of the ECS service's IAM role"
+  value       = "${aws_iam_role.service.name}"
+}

--- a/tf/modules/services/base/web-basic/variables.tf
+++ b/tf/modules/services/base/web-basic/variables.tf
@@ -1,0 +1,138 @@
+variable "name" {
+  description = "Service name"
+}
+
+variable "project" {
+  description = "Project tag value"
+}
+
+variable "cluster_id" {
+  description = "ECS cluster to deploy into"
+}
+
+variable "subnets" {
+  description = "List of subnets to load balance"
+  type        = "list"
+}
+
+variable "vpc" {
+  description = "ID of the VPC that the cluster is deployed in"
+}
+
+variable "hostname" {
+  description = "(Optional) Hostname to register in Route53"
+}
+
+variable "domain" {
+  description = "Apex domain to use (e.g. dlcs.io)"
+}
+
+variable "path_patterns" {
+  description = "Path patterns to match in ALB"
+  type        = "list"
+
+  default = [
+    "/*",
+  ]
+}
+
+variable "zone_id" {
+  description = "ID for the Hosted Zone"
+}
+
+variable "load_balancer_arn" {
+  description = "Optional ARN of ALB to attach to"
+  default     = ""
+}
+
+variable "load_balancer_fqdn" {
+  description = "Optional FQDN of ALB to attach to"
+  default     = ""
+}
+
+variable "load_balancer_zone_id" {
+  description = "Optional Zone ID of ALB to attach to"
+  default     = ""
+}
+
+variable "service_number_http" {
+  description = "Priority number for the service's ALB HTTP listener"
+  default     = "0"
+}
+
+variable "service_number_https" {
+  description = "Priority number for the service's ALB HTTPS listener"
+  default     = "0"
+}
+
+variable "load_balancer_http_listener_arn" {
+  description = "Optional ARN of the ALB HTTP Listener to attach to"
+  default     = ""
+}
+
+variable "load_balancer_https_listener_arn" {
+  description = "Optional ARN of the ALB HTTPS Listener to attach to"
+  default     = ""
+}
+
+variable "desired_count" {
+  description = "Desired number of services"
+  default     = 1
+}
+
+variable "container_port" {
+  description = "Port number of container"
+}
+
+variable "container_name" {
+  description = "Name of container"
+}
+
+variable "task_definition_arn" {
+  description = "ARN of the ECS Task Definition"
+}
+
+variable "health_check_matcher" {
+  description = "List of HTTP status codes for health check"
+  default     = "200,404"
+}
+
+variable "health_check_path" {
+  description = "Path to test HTTP status for health check"
+  default     = "/"
+}
+
+variable "health_check_timeout" {
+  description = "Timeout for health check (seconds)"
+  default     = 10
+}
+
+variable "health_check_healthy_threshold" {
+  description = "Threshold for number of healthy checks"
+  default     = 2
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = "Threshold for number of unhealthy checks"
+  default     = 2
+}
+
+variable "health_check_interval" {
+  description = "Interval between health checks (seconds)"
+  default     = 30
+}
+
+variable "deregistration_delay" {
+  description = "Target group deregistration delay (seconds)"
+  default     = 30
+}
+
+variable "health_check_grace_period_seconds" {
+  description = "Grace period for health check (seconds)"
+  default     = 0
+}
+
+variable "scheduling_strategy" {
+  description = "Use REPLICA or DAEMON scheduling strategy"
+  default     = "REPLICA"
+}

--- a/tf/modules/services/base/web-basic/variables.tf
+++ b/tf/modules/services/base/web-basic/variables.tf
@@ -37,22 +37,19 @@ variable "path_patterns" {
 }
 
 variable "zone_id" {
-  description = "ID for the Hosted Zone"
+  description = "ID for the Route53 Hosted Zone"
 }
 
 variable "load_balancer_arn" {
-  description = "Optional ARN of ALB to attach to"
-  default     = ""
+  description = "ARN of ALB to attach to"
 }
 
 variable "load_balancer_fqdn" {
-  description = "Optional FQDN of ALB to attach to"
-  default     = ""
+  description = "FQDN of ALB to attach to"
 }
 
 variable "load_balancer_zone_id" {
-  description = "Optional Zone ID of ALB to attach to"
-  default     = ""
+  description = "Zone ID of ALB to attach to"
 }
 
 variable "service_number_http" {


### PR DESCRIPTION
This is a new, stripped-down version of the `web` ECS service module.

It removes the optional creation of an ALB, including all the security group and certificate handling.
It also removes the `create_route53_entry` flag, instead switching behaviour based upon whether the `hostname` parameter has been filled.
ALB listener rules are created for each entry in the `path_patterns` parameter, and their criteria for Host header matching are switched based on `hostname` being used. Similarly, the Route53 DNS entry is only created if a hostname has been passed.
The parameters carrying basic information for the ALB to attach to have become mandatory, while keeping the ALB Listener ARN parameters optional. The expectation is that the caller will fill one or both of these parameters.