### PR TITLE
Add desired capacity cluster property

### DIFF
--- a/tf/modules/clusters/borg/README.md
+++ b/tf/modules/clusters/borg/README.md
@@ -31,6 +31,7 @@ The following parameters are available:
 | dockerhub_email          | DockerHub robot email                        | string |           |
 | min_size                 | Minimum number of instances for the cluster  | string | 1         |
 | max_size                 | Maximum number of instances for the cluster  | string | 1         |
+| desired_capacity         | Desired number of instances for the cluster  | string | 1         |
 | root_size                | Size in GB for the root partition            | string | 40        |
 | docker_size              | Size in GB of the Docker volume              | string | 40        |
 | data_ebs_size            | Size in GB of the EBS volume                 | string | 100       |

--- a/tf/modules/clusters/borg/main.tf
+++ b/tf/modules/clusters/borg/main.tf
@@ -320,6 +320,7 @@ resource "aws_autoscaling_group" "borg" {
 
   max_size            = var.max_size
   min_size            = var.min_size
+  desired_capacity    = var.desired_capacity
   vpc_zone_identifier = flatten(var.subnets)
 
   default_cooldown = 0

--- a/tf/modules/clusters/borg/variables.tf
+++ b/tf/modules/clusters/borg/variables.tf
@@ -63,6 +63,11 @@ variable "max_size" {
   default     = 1
 }
 
+variable "desired_capacity" {
+  description = "The number of Amazon EC2 instances that should be running in the group"
+  default     = 1
+}
+
 variable "root_size" {
   description = "Size in GB for the root partition"
   default     = 40


### PR DESCRIPTION
Primarily so I can set desired capacity to 0 to shut dev instances down when not required, via tf.
See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#desired_capacity
