### PR TITLE
Consistent handling of host-header for aws_alb_listener_rule.http

### DIFF
--- a/tf/modules/services/base/web/main.tf
+++ b/tf/modules/services/base/web/main.tf
@@ -222,7 +222,7 @@ resource "aws_alb_listener_rule" "http" {
 
   condition {
     field  = "host-header"
-    values = ["${var.hostname}.${var.domain}"]
+    values = ["${var.hostname == "" ? "${var.domain}" : "${var.hostname}.${var.domain}"}"]
   }
 
   condition {


### PR DESCRIPTION
The logic for aws_alb_listener_rule.http differed from other impls in that it doesn't check for empty hostname.

This can result in invalid rules for `".{domain}"` rather than `"{domain}"`