### PR TITLE
Tweak to fix SQS module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -91,3 +91,7 @@ Removed `services/base/worker` and `services/base/web-basic` modules.
 ## 3.9 2022-11-10
 
 Ignore changes to `desired_count` for web_fargate and web_ecs.
+
+## 3.10 2022-12-06
+
+Fix SQS module to use topic_arn for `aws:SourceArn` condition, rather than topic_name

--- a/tf/modules/messaging/sqs/queue_policy.tf
+++ b/tf/modules/messaging/sqs/queue_policy.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "sns_write_to_queue" {
       variable = "aws:SourceArn"
 
       values = [
-        var.topic_name
+        local.topic_arn
       ]
     }
   }

--- a/tf/modules/messaging/sqs/sns.tf
+++ b/tf/modules/messaging/sqs/sns.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic_subscription" "sns_topic" {
   protocol  = "sqs"
-  topic_arn = format("arn:aws:sns:%s:%s:%s", var.region, var.account_id, var.topic_name)
+  topic_arn = local.topic_arn
   endpoint  = aws_sqs_queue.q.arn
 }

--- a/tf/modules/messaging/sqs/variables.tf
+++ b/tf/modules/messaging/sqs/variables.tf
@@ -1,13 +1,13 @@
+locals {
+  topic_arn = format("arn:aws:sns:%s:%s:%s", var.region, var.account_id, var.topic_name)
+}
+
 variable "project" {
   description = "Project value for tags"
 }
 
 variable "queue_name" {
   description = "Name of the SQS queue to create"
-}
-
-variable "topic_count" {
-  default = "1"
 }
 
 variable "topic_name" {


### PR DESCRIPTION
Fix SQS module to use topic_arn for `aws:SourceArn` condition in policy, rather than topic_name