### PR TITLE
Tweaks for grobid work

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -102,4 +102,6 @@ Update SQS module to allow setting of `raw_message_delivery` on SNS subscription
 
 ## 3.12 2023-02-03
 
-Remove "Project" tag from everywhere with exception of ASG creation. Expectation is that `default_tags` will be used to set project from calling modules
+Remove "Project" tag from everywhere with exception of ASG creation. Expectation is that `default_tags` will be used to set project from calling modules.
+
+Add "resourceRequirements" to ecs/container_definition.

--- a/changelog.md
+++ b/changelog.md
@@ -99,3 +99,7 @@ Fix SQS module to use topic_arn for `aws:SourceArn` condition, rather than topic
 ## 3.11 2023-01-12
 
 Update SQS module to allow setting of `raw_message_delivery` on SNS subscription.
+
+## 3.12 2023-02-03
+
+Remove "Project" tag from everywhere with exception of ASG creation. Expectation is that `default_tags` will be used to set project from calling modules

--- a/tf/modules/bastion/main.tf
+++ b/tf/modules/bastion/main.tf
@@ -23,10 +23,6 @@ resource "aws_security_group" "bastion" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    Project = var.project
-  }
 }
 
 data "aws_iam_policy_document" "assume_role_policy_ec2" {

--- a/tf/modules/clusters/borg/main.tf
+++ b/tf/modules/clusters/borg/main.tf
@@ -124,10 +124,6 @@ resource "aws_security_group" "borg" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    "Project" = var.project
-  }
 }
 
 resource "aws_security_group" "borg_peering" {
@@ -155,10 +151,6 @@ resource "aws_security_group" "borg_peering" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    "Project" = var.project
   }
 }
 

--- a/tf/modules/clusters/borg/volume.tf
+++ b/tf/modules/clusters/borg/volume.tf
@@ -4,7 +4,6 @@ resource "aws_efs_file_system" "data" {
   tags = {
     Name        = var.cluster_name
     Environment = var.prefix
-    Project     = var.project
     ManagedBy   = "Terraform"
   }
 }
@@ -26,10 +25,6 @@ resource "aws_security_group" "mount_target" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Project = var.project
   }
 }
 

--- a/tf/modules/clusters/standard/main.tf
+++ b/tf/modules/clusters/standard/main.tf
@@ -96,11 +96,6 @@ resource "aws_security_group" "cluster" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    Project   = var.project
-    Terraform = true
-  }
 }
 
 resource "aws_iam_instance_profile" "standard" {

--- a/tf/modules/clusters/standard/volume.tf
+++ b/tf/modules/clusters/standard/volume.tf
@@ -4,7 +4,6 @@ resource "aws_efs_file_system" "data" {
   tags = {
     Name        = var.cluster_name
     Environment = var.prefix
-    Project     = var.project
     ManagedBy   = "Terraform"
   }
 }
@@ -26,10 +25,6 @@ resource "aws_security_group" "mount_target" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Project = var.project
   }
 }
 

--- a/tf/modules/ecs/container_definition/main.tf
+++ b/tf/modules/ecs/container_definition/main.tf
@@ -31,5 +31,7 @@ locals {
     systemControls = var.system_controls
 
     repositoryCredentials = var.repository_credentials
+
+    resourceRequirements = var.resource_requirements
   }
 }

--- a/tf/modules/ecs/container_definition/variables.tf
+++ b/tf/modules/ecs/container_definition/variables.tf
@@ -132,3 +132,11 @@ variable "links" {
   type = list(string)
   default = []
 }
+
+variable "resource_requirements" {
+  type = list(object({
+    type  = string
+    value = string
+  }))
+  default = []
+}

--- a/tf/modules/ecs/web_ec2/main.tf
+++ b/tf/modules/ecs/web_ec2/main.tf
@@ -2,7 +2,6 @@ module "target" {
   source = "../../load-balancing/target"
 
   name                             = var.name
-  project                          = var.project
   vpc                              = var.vpc
   hostname                         = var.hostname
   domain                           = var.domain
@@ -84,10 +83,6 @@ resource "aws_ecs_service" "service" {
   depends_on = [
     aws_iam_role_policy.service
   ]
-
-  tags = {
-    Project = var.project
-  }
 }
 
 # IAM

--- a/tf/modules/ecs/web_ec2/variables.tf
+++ b/tf/modules/ecs/web_ec2/variables.tf
@@ -2,10 +2,6 @@ variable "name" {
   description = "Service name"
 }
 
-variable "project" {
-  description = "Project tag value"
-}
-
 variable "cluster_id" {
   description = "ECS cluster to deploy into"
 }

--- a/tf/modules/ecs/web_fargate/main.tf
+++ b/tf/modules/ecs/web_fargate/main.tf
@@ -2,7 +2,6 @@ module "target" {
   source = "../../load-balancing/target"
 
   name                             = var.name
-  project                          = var.project
   vpc                              = var.vpc
   hostname                         = var.hostname
   domain                           = var.domain
@@ -82,9 +81,5 @@ resource "aws_ecs_service" "service" {
     ignore_changes = [
       desired_count
     ]
-  }
-
-  tags = {
-    Project = var.project
   }
 }

--- a/tf/modules/ecs/web_fargate/variables.tf
+++ b/tf/modules/ecs/web_fargate/variables.tf
@@ -2,10 +2,6 @@ variable "name" {
   description = "Service name"
 }
 
-variable "project" {
-  description = "Project tag value"
-}
-
 variable "cluster_id" {
   description = "ECS cluster to deploy into"
 }

--- a/tf/modules/iam-baseline/README.md
+++ b/tf/modules/iam-baseline/README.md
@@ -7,6 +7,5 @@ This sets up basic IAM groups, group policies and Force_MFA support.
 | Name          | Description              | Type   | Default |
 |---------------|--------------------------|--------|---------|
 | prefix        | Prefix for AWS resources | string |         |
-| project       | Project tag value        | string |         |
 | account_id    | AWS account ID           | string |         |
 | account_alias | AWS account alias        | string |         |

--- a/tf/modules/iam-baseline/variables.tf
+++ b/tf/modules/iam-baseline/variables.tf
@@ -1,7 +1,3 @@
-variable "project" {
-  description = "Project tag value"
-}
-
 variable "prefix" {
   description = "Prefix for AWS resources"
 }

--- a/tf/modules/load-balancing/target/main.tf
+++ b/tf/modules/load-balancing/target/main.tf
@@ -32,10 +32,6 @@ resource "aws_security_group" "web" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    Project = var.project
-  }
 }
 
 #############################
@@ -57,10 +53,6 @@ resource "aws_alb_target_group" "service" {
     unhealthy_threshold = var.health_check_unhealthy_threshold
     interval            = var.health_check_interval
     matcher             = var.health_check_matcher
-  }
-
-  tags = {
-    Project = var.project
   }
 }
 
@@ -89,10 +81,6 @@ resource "aws_alb_listener_rule" "http" {
     ignore_changes = [
       priority
     ]
-  }
-  
-  tags = {
-    Project = var.project
   }
 }
 

--- a/tf/modules/load-balancing/target/readme.md
+++ b/tf/modules/load-balancing/target/readme.md
@@ -12,7 +12,6 @@ This module creates the following resources:
 | Name                             | Description                                                                      | Default       |
 |----------------------------------|----------------------------------------------------------------------------------|---------------|
 | name                             | Name of target group                                                             |               |
-| project                          | Project tag value                                                                |               |
 | vpc                              | Id of the VPC that LB is in                                                      |               |
 | hostname                         | Optional hostname, prepended to `domain`, for `host_header` rule                 | ""            |
 | domain                           | Hostname for LB rule                                                             |               |

--- a/tf/modules/load-balancing/target/variables.tf
+++ b/tf/modules/load-balancing/target/variables.tf
@@ -2,10 +2,6 @@ variable "name" {
   description = "Name of target group"
 }
 
-variable "project" {
-  description = "Project tag value"
-}
-
 variable "vpc" {
   description = "ID of the VPC that the ALB is deployed in"
 }

--- a/tf/modules/load-balancing/wildcard-alb/README.md
+++ b/tf/modules/load-balancing/wildcard-alb/README.md
@@ -5,7 +5,6 @@ This module will provide an Application Load Balancer that specifically expects 
 ## Parameters
 | Name                   | Description                                         | Type   | Default                   |
 |------------------------|-----------------------------------------------------|--------|---------------------------|
-| project                | Project name for tag values                         | string |                           |
 | prefix                 | Prefix for AWS resources                            | string |                           |
 | name                   | Suffix for load balancer appliance                  | string |                           |
 | subnets                | List of subnets to associate load balancer with     | list   |                           |

--- a/tf/modules/load-balancing/wildcard-alb/main.tf
+++ b/tf/modules/load-balancing/wildcard-alb/main.tf
@@ -30,10 +30,6 @@ resource "aws_security_group" "web" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    Project = var.project
-  }
 }
 
 #######
@@ -53,10 +49,6 @@ resource "aws_alb" "lb" {
   )
 
   idle_timeout = var.idle_timeout_seconds
-
-  tags = {
-    Project = var.project
-  }
 }
 
 resource "aws_alb_target_group" "default" {

--- a/tf/modules/load-balancing/wildcard-alb/variables.tf
+++ b/tf/modules/load-balancing/wildcard-alb/variables.tf
@@ -2,10 +2,6 @@ variable "prefix" {
   description = "Prefix for AWS resources"
 }
 
-variable "project" {
-  description = "Project name for tag values"
-}
-
 variable "name" {
   description = "Suffix for load balancer appliance"
 }

--- a/tf/modules/messaging/sns/variables.tf
+++ b/tf/modules/messaging/sns/variables.tf
@@ -1,7 +1,3 @@
 variable "name" {
   description = "Name of the SNS topic"
 }
-
-variable "project" {
-  description = "Project value for tags"
-}

--- a/tf/modules/messaging/sqs/sqs.tf
+++ b/tf/modules/messaging/sqs/sqs.tf
@@ -9,16 +9,8 @@ resource "aws_sqs_queue" "q" {
   receive_wait_time_seconds  = var.receive_wait_time_seconds
 
   redrive_policy = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.dlq.arn}\",\"maxReceiveCount\":${var.max_receive_count}}"
-
-  tags = {
-    "Project" = var.project
-  }
 }
 
 resource "aws_sqs_queue" "dlq" {
   name = "${var.queue_name}_dlq"
-
-  tags = {
-    "Project" = var.project
-  }
 }

--- a/tf/modules/messaging/sqs/variables.tf
+++ b/tf/modules/messaging/sqs/variables.tf
@@ -2,10 +2,6 @@ locals {
   topic_arn = format("arn:aws:sns:%s:%s:%s", var.region, var.account_id, var.topic_name)
 }
 
-variable "project" {
-  description = "Project value for tags"
-}
-
 variable "queue_name" {
   description = "Name of the SQS queue to create"
 }

--- a/tf/modules/services/base/web/README.md
+++ b/tf/modules/services/base/web/README.md
@@ -44,7 +44,6 @@ Creates Route53 entry if `create_route53_entry` is `true`.
 | load\_balancer\_zone\_id              | Optional Zone ID of ALB to attach to                 | `string` | `""`                               |    no    |
 | name                                  | Service name                                         | `any`    | n/a                                |   yes    |
 | path\_patterns                        | Path patterns to match in ALB                        | `list`   | <pre>[<br>  "/*"<br>]</pre>        |    no    |
-| project                               | Project tag value                                    | `any`    | n/a                                |   yes    |
 | scheduling\_strategy                  | Use REPLICA or DAEMON scheduling strategy            | `string` | `"REPLICA"`                        |    no    |
 | service\_number\_http                 | Priority number for the service's ALB HTTP listener  | `string` | `"0"`                              |    no    |
 | service\_number\_https                | Priority number for the service's ALB HTTPS listener | `string` | `"0"`                              |    no    |

--- a/tf/modules/services/base/web/main.tf
+++ b/tf/modules/services/base/web/main.tf
@@ -130,10 +130,6 @@ resource "aws_security_group" "web" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = {
-    Project = var.project
-  }
 }
 
 #############################
@@ -151,10 +147,6 @@ resource "aws_alb" "service" {
     join("", aws_security_group.web.*.id),
     data.aws_security_group.default.id,
   ]
-
-  tags = {
-    Project = var.project
-  }
 }
 
 resource "aws_alb_target_group" "service" {

--- a/tf/modules/services/base/web/variables.tf
+++ b/tf/modules/services/base/web/variables.tf
@@ -2,10 +2,6 @@ variable "name" {
   description = "Service name"
 }
 
-variable "project" {
-  description = "Project tag value"
-}
-
 variable "cluster_id" {
   description = "ECS cluster to deploy into"
 }

--- a/tf/modules/vpc/README.md
+++ b/tf/modules/vpc/README.md
@@ -9,7 +9,6 @@ Provides a single VPC with default 3 public and private subnets. Also creates s3
 | vpc_name   | Name of VPC                         | string |             |
 | region     | AWS region                          | string |             |
 | cidr_block | VPC CIDR block                      | string | 10.0.0.0/16 |
-| project    | "Project" tag to apply to resources | string |             |
 
 ## Outputs
 | Parameter              | Description                     | Type   |

--- a/tf/modules/vpc/variables.tf
+++ b/tf/modules/vpc/variables.tf
@@ -16,7 +16,3 @@ variable "cidr_block" {
   description = "VPC CIDR block"
   default     = "10.0.0.0/16"
 }
-
-variable "project" {
-  description = "Project tag value"
-}


### PR DESCRIPTION
Remove `var.project` from most places - can use `default_tags` on provider if required.

Add [`resourceRequirements`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-resourcerequirement.html) for container_definition