### PR TITLE
Output instance role name for capacity providers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -138,3 +138,7 @@ Allow `min_size` to set for capacity provider ASG
 Add `/vpc/legacy` module. This was removed in `3.0` in favour of much more flexible vpc module. 
 
 Re-adding to allow estates that already use it to leverage `default_tags` without TF always detecting changes.
+
+## 3.19 2023-06-28
+
+Output `instance_role_name` from `/ecs/ec2_capacity_provider*` modules - this will allow adding further permissions as required.

--- a/tf/modules/ecs/ec2_capacity_provider/iam/outputs.tf
+++ b/tf/modules/ecs/ec2_capacity_provider/iam/outputs.tf
@@ -1,3 +1,7 @@
 output "instance_profile_arn" {
   value = aws_iam_instance_profile.instance_profile.arn
 }
+
+output "instance_role_name" {
+  value = aws_iam_role.instance_role.id
+}

--- a/tf/modules/ecs/ec2_capacity_provider/outputs.tf
+++ b/tf/modules/ecs/ec2_capacity_provider/outputs.tf
@@ -1,3 +1,7 @@
 output "name" {
   value = aws_ecs_capacity_provider.capacity_provider.name
 }
+
+output "instance_role_name" {
+  value = module.iam.instance_role_name
+}

--- a/tf/modules/ecs/ec2_capacity_provider_abs/outputs.tf
+++ b/tf/modules/ecs/ec2_capacity_provider_abs/outputs.tf
@@ -1,3 +1,7 @@
 output "name" {
   value = aws_ecs_capacity_provider.capacity_provider.name
 }
+
+output "instance_role_name" {
+  value = module.iam.instance_role_name
+}


### PR DESCRIPTION
This is to allow adding more granular permissions to cluster