### PR TITLE
Updates to bastion + vpc modules

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -146,3 +146,16 @@ Output `instance_role_name` from `/ecs/ec2_capacity_provider*` modules - this wi
 ## 3.20 2023-07-28
 
 Adding in a `filter_policy` variable to the `sqs` module that allows a filter policy to be set on an SNS subscription to a queue
+
+## 3.21 2023-09-11
+
+Updates to `bastion` module:
+* Remove use of default SG
+* Default to `t3a.micro` instance
+* Default to Amazon Linux 2023 ami if not specified
+* Update to use IMDSv2 for getting public IP
+* Switch from launch-configuration to launch-template
+* Output bastion role
+
+Updates to `vpc` module:
+* Remove deprecated syntax in `aws_eip`

--- a/tf/modules/bastion/README.md
+++ b/tf/modules/bastion/README.md
@@ -1,28 +1,31 @@
 # Bastion module
 
-This is an EC2 instance that provides SSH access to private subnet(s). It will be provisioned with an ASG and will register itself with Route53 on startup.
+This is an EC2 instance that provides SSH access to private subnet(s). 
+
+It will be provisioned with an ASG and will register itself with Route53 on startup.
 
 ## Parameters
 The following parameters are available:
 
-| Parameter     | Description                                                   | Type   | Default  |
-|---------------|---------------------------------------------------------------|--------|----------|
-| ami           | AMI to use (should be ECS optimised x64)                      | string |          |
-| instance_type | EC2 instance type                                             | string | t2.micro |
-| prefix        | Prefix for AWS resources                                      | string |          |
-| project       | Project tag value                                             | string |          |
-| key_name      | EC2 key pair name to use                                      | string |          |
-| vpc           | VPC to join                                                   | string |          |
-| ssh_cidr_list | List of CIDR blocks to allow SSH access for                   | list   | []       |
-| subnet        | VPC subnet to launch in                                       | string |          |
-| dns_zone      | DNS Hosted Zone ID to create bastion record within            | string |          |
-| domain        | Apex domain to use (e.g. dlcs.io)                             | string |          |
-| hostname      | Hostname to register bastion record with. Prepended to domain | number | 1        |
-| min_size      | Minimum number of instances                                   | number | 1        |
-| max_size      | Maximum number of instances                                   | number | 1        |
+| Parameter                  | Description                                                   | Type   | Default       |
+| -------------------------- | ------------------------------------------------------------- | ------ | ------------- |
+| ami                        | AMI to use                                                    | string | latest AL2023 |
+| instance_type              | EC2 instance type                                             | string | t3a.micro     |
+| prefix                     | Prefix for AWS resources                                      | string |               |
+| key_name                   | EC2 key pair name to use                                      | string |               |
+| vpc                        | VPC to join                                                   | string |               |
+| ip_whitelist               | List of CIDR blocks to allow SSH access for                   | list   | []            |
+| subnets                    | VPC subnets to launch in                                      | string |               |
+| dns_zone                   | DNS Hosted Zone ID to create bastion record within            | string |               |
+| domain                     | Apex domain to use (e.g. dlcs.io)                             | string |               |
+| hostname                   | Hostname to register bastion record with. Prepended to domain | string | bastion       |
+| min_size                   | Minimum number of instances                                   | number | 1             |
+| max_size                   | Maximum number of instances                                   | number | 1             |
+| additional_security_groups | Additional security groups to assign                          | list   | []            |
 
 ## Outputs
 
 | Parameter              | Description                        | Type   |
-|------------------------|------------------------------------|--------|
+| ---------------------- | ---------------------------------- | ------ |
 | bastion_security_group | ID of the bastion's security group | string |
+| role                   | Name of the bastion's role         | string |

--- a/tf/modules/bastion/output.tf
+++ b/tf/modules/bastion/output.tf
@@ -1,3 +1,7 @@
 output "bastion_security_group" {
   value = aws_security_group.bastion.id
 }
+
+output "role" {
+  value = aws_iam_role.bastion.name
+}

--- a/tf/modules/bastion/variables.tf
+++ b/tf/modules/bastion/variables.tf
@@ -7,21 +7,18 @@ variable "ip_whitelist" {
   type        = list(string)
 }
 
-variable "project" {
-  description = "Project name for tag values"
-}
-
 variable "prefix" {
   description = "Prefix for AWS resources"
 }
 
 variable "instance_type" {
   description = "EC2 instance type"
-  default     = "t2.micro"
+  default     = "t3a.micro"
 }
 
 variable "ami" {
-  description = "AMI to use (should be ECS optimised x64)"
+  description = "AMI to use, defaults to latest amazon linux 2023 if not provided"
+  default     = ""
 }
 
 variable "key_name" {
@@ -54,4 +51,9 @@ variable "min_size" {
 variable "max_size" {
   description = "Maximum number of instances for the cluster"
   default     = 1
+}
+
+variable "additional_security_groups" {
+  description = "Additional security groups to assign to Bastion host"
+  default     = []
 }

--- a/tf/modules/bastion/variables.tf
+++ b/tf/modules/bastion/variables.tf
@@ -18,7 +18,7 @@ variable "instance_type" {
 
 variable "ami" {
   description = "AMI to use, defaults to latest amazon linux 2023 if not provided"
-  default     = ""
+  default     = null
 }
 
 variable "key_name" {

--- a/tf/modules/vpc/nat/main.tf
+++ b/tf/modules/vpc/nat/main.tf
@@ -1,5 +1,5 @@
 resource "aws_eip" "nat" {
-  vpc = true
+  domain = "vpc"
 
   tags = {
     Name = var.name


### PR DESCRIPTION
Updates to `bastion` module:
* Remove use of default SG
* Default to `t3a.micro` instance
* Default to Amazon Linux 2023 ami if not specified
* Update to use IMDSv2 for getting public IP
* Switch from launch-configuration to launch-template
* Output bastion role

Updates to `vpc` module:
* Remove deprecated syntax in `aws_eip`