### PR TITLE
Adding ability to add stickiness to an ALB target groups

### DIFF
--- a/tf/modules/ecs/web_ec2/main.tf
+++ b/tf/modules/ecs/web_ec2/main.tf
@@ -19,6 +19,8 @@ module "target" {
   health_check_unhealthy_threshold = var.health_check_unhealthy_threshold
   health_check_interval            = var.health_check_interval
   deregistration_delay             = var.deregistration_delay
+  stickiness_enabled               = var.load_balancer_stickiness_enabled
+  stickiness_cookie_name           = var.stickiness_cookie_name # required if stickiness is enabled
   target_type                      = "instance"
 }
 

--- a/tf/modules/ecs/web_ec2/variables.tf
+++ b/tf/modules/ecs/web_ec2/variables.tf
@@ -141,3 +141,13 @@ variable "placement_constraints" {
   }))
   default = []
 }
+
+variable "load_balancer_stickiness_enabled" {
+  description = "whether stickiness should be enabled or not"
+  default     = false
+}
+
+variable "stickiness_cookie_name" {
+  description = "name of the cookie used for stickiness"
+  default     = ""
+}

--- a/tf/modules/ecs/web_ec2/variables.tf
+++ b/tf/modules/ecs/web_ec2/variables.tf
@@ -143,11 +143,11 @@ variable "placement_constraints" {
 }
 
 variable "load_balancer_stickiness_enabled" {
-  description = "whether stickiness should be enabled or not"
+  description = "Whether stickiness should be enabled or not"
   default     = false
 }
 
 variable "stickiness_cookie_name" {
-  description = "name of the cookie used for stickiness"
+  description = "Name of the cookie used for stickiness"
   default     = ""
 }

--- a/tf/modules/load-balancing/target/main.tf
+++ b/tf/modules/load-balancing/target/main.tf
@@ -46,6 +46,12 @@ resource "aws_alb_target_group" "service" {
   deregistration_delay = var.deregistration_delay
   target_type          = var.target_type
 
+  stickiness {
+    enabled            = var.stickiness_enabled
+    type               = "app_cookie"
+    name               = var.stickiness_cookie_name
+  }
+
   health_check {
     path                = var.health_check_path
     timeout             = var.health_check_timeout

--- a/tf/modules/load-balancing/target/variables.tf
+++ b/tf/modules/load-balancing/target/variables.tf
@@ -94,11 +94,11 @@ variable "target_type" {
 }
 
 variable "stickiness_enabled" {
-  description = "whether stickiness should be enabled or not"
+  description = "Whether stickiness should be enabled or not"
   default     = false
 }
 
 variable "stickiness_cookie_name" {
-  description = "name of the cookie used for stickiness"
+  description = "Name of the cookie used for stickiness"
   default     = ""
 }

--- a/tf/modules/load-balancing/target/variables.tf
+++ b/tf/modules/load-balancing/target/variables.tf
@@ -92,3 +92,13 @@ variable "target_type" {
   description = "TargetType for ELB TargetGroup"
   default     = "instance"
 }
+
+variable "stickiness_enabled" {
+  description = "whether stickiness should be enabled or not"
+  default     = false
+}
+
+variable "stickiness_cookie_name" {
+  description = "name of the cookie used for stickiness"
+  default     = ""
+}


### PR DESCRIPTION
This PR updates the load balancer target groups to allow stickiness based on an app_cookie if enabled.  Additionally the `web_ec2` project has been updated to allow stickiness to be enabled