### PR TITLE
Allow control of min/max percent and LB algorithm

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -190,4 +190,10 @@ Add default_tags to ASG resources for `ecs/ec2_capacity_provider` and `ecs/ec2_c
 
 ## 3.29 2024-06-28
 
-Update stickiness to allow for choosing whether to use `lb_cookie` or `app_cookie` and extend to web_fargate
+Update stickiness to allow for choosing whether to use `lb_cookie` or `app_cookie` and extend to `ecs/web_fargate`
+
+## 3.30 2024-07-09
+
+Allow deployment min/max percent to be set for ECS services in `ecs/web_fargate` and `ecs/web_ec2`.
+
+Allow load-balancing algorithm to be controlled in `load-balancing/target` (extended to `ecs/web_fargate` and `ecs/web_ec2`)

--- a/tf/modules/ecs/web_ec2/main.tf
+++ b/tf/modules/ecs/web_ec2/main.tf
@@ -1,29 +1,31 @@
 module "target" {
   source = "../../load-balancing/target"
 
-  name                             = var.name
-  vpc                              = var.vpc
-  hostname                         = var.hostname
-  domain                           = var.domain
-  path_patterns                    = var.path_patterns
-  zone_id                          = var.zone_id
-  create_route53_entry             = var.create_route53_entry
-  ip_whitelist                     = var.ip_whitelist
-  load_balancer_arn                = var.load_balancer_arn
-  listener_arn                     = var.listener_arn
-  priority                         = var.priority
-  health_check_matcher             = var.health_check_matcher
-  health_check_path                = var.health_check_path
-  health_check_timeout             = var.health_check_timeout
-  health_check_healthy_threshold   = var.health_check_healthy_threshold
-  health_check_unhealthy_threshold = var.health_check_unhealthy_threshold
-  health_check_interval            = var.health_check_interval
-  deregistration_delay             = var.deregistration_delay
-  target_type                      = "instance"
-  stickiness_enabled               = var.load_balancer_stickiness_enabled
-  stickiness_type                  = var.stickiness_type
-  stickiness_cookie_duration       = var.stickiness_cookie_duration
-  stickiness_cookie_name           = var.stickiness_cookie_name
+  name                              = var.name
+  vpc                               = var.vpc
+  hostname                          = var.hostname
+  domain                            = var.domain
+  path_patterns                     = var.path_patterns
+  zone_id                           = var.zone_id
+  create_route53_entry              = var.create_route53_entry
+  ip_whitelist                      = var.ip_whitelist
+  load_balancer_arn                 = var.load_balancer_arn
+  listener_arn                      = var.listener_arn
+  priority                          = var.priority
+  health_check_matcher              = var.health_check_matcher
+  health_check_path                 = var.health_check_path
+  health_check_timeout              = var.health_check_timeout
+  health_check_healthy_threshold    = var.health_check_healthy_threshold
+  health_check_unhealthy_threshold  = var.health_check_unhealthy_threshold
+  health_check_interval             = var.health_check_interval
+  deregistration_delay              = var.deregistration_delay
+  target_type                       = "instance"
+  stickiness_enabled                = var.load_balancer_stickiness_enabled
+  stickiness_type                   = var.stickiness_type
+  stickiness_cookie_duration        = var.stickiness_cookie_duration
+  stickiness_cookie_name            = var.stickiness_cookie_name
+  load_balancing_algorithm          = var.load_balancing_algorithm
+  load_balancing_anomaly_mitigation = var.load_balancing_anomaly_mitigation
 }
 
 # Service
@@ -35,6 +37,9 @@ resource "aws_ecs_service" "service" {
   iam_role        = aws_iam_role.service.id
 
   health_check_grace_period_seconds = var.health_check_grace_period_seconds
+
+  deployment_maximum_percent         = var.deployment_max_percent
+  deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
 
   load_balancer {
     target_group_arn = module.target.target_group_arn

--- a/tf/modules/ecs/web_ec2/variables.tf
+++ b/tf/modules/ecs/web_ec2/variables.tf
@@ -122,7 +122,7 @@ variable "scheduling_strategy" {
 }
 
 variable "capacity_provider_strategies" {
-  type = list(any)
+  type    = list(any)
   default = []
 }
 
@@ -160,4 +160,24 @@ variable "stickiness_type" {
 variable "stickiness_cookie_name" {
   description = "Name of the cookie used for stickiness. Only required for the app_cookie type"
   default     = ""
+}
+
+variable "load_balancing_algorithm" {
+  description = "Determines how the load balancer selects targets when routing requests"
+  default     = "round_robin"
+}
+
+variable "load_balancing_anomaly_mitigation" {
+  description = "Determines whether to enable target anomaly mitigation. Target anomaly mitigation is only supported if load_balancing_algorithm='weighted_random'"
+  default     = "off"
+}
+
+variable "deployment_max_percent" {
+  description = "Upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment"
+  default     = 200
+}
+
+variable "deployment_min_healthy_percent" {
+  description = "Lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment"
+  default     = 100
 }

--- a/tf/modules/ecs/web_fargate/main.tf
+++ b/tf/modules/ecs/web_fargate/main.tf
@@ -1,27 +1,29 @@
 module "target" {
   source = "../../load-balancing/target"
 
-  name                             = var.name
-  vpc                              = var.vpc
-  hostname                         = var.hostname
-  domain                           = var.domain
-  path_patterns                    = var.path_patterns
-  zone_id                          = var.zone_id
-  create_route53_entry             = var.create_route53_entry
-  ip_whitelist                     = var.ip_whitelist
-  load_balancer_arn                = var.load_balancer_arn
-  listener_arn                     = var.listener_arn
-  priority                         = var.priority
-  health_check_matcher             = var.health_check_matcher
-  health_check_path                = var.health_check_path
-  health_check_timeout             = var.health_check_timeout
-  health_check_healthy_threshold   = var.health_check_healthy_threshold
-  health_check_unhealthy_threshold = var.health_check_unhealthy_threshold
-  health_check_interval            = var.health_check_interval
-  deregistration_delay             = var.deregistration_delay
-  target_type                      = "ip"
-  stickiness_enabled               = var.load_balancer_stickiness_enabled
-  stickiness_cookie_duration       = var.stickiness_cookie_duration
+  name                              = var.name
+  vpc                               = var.vpc
+  hostname                          = var.hostname
+  domain                            = var.domain
+  path_patterns                     = var.path_patterns
+  zone_id                           = var.zone_id
+  create_route53_entry              = var.create_route53_entry
+  ip_whitelist                      = var.ip_whitelist
+  load_balancer_arn                 = var.load_balancer_arn
+  listener_arn                      = var.listener_arn
+  priority                          = var.priority
+  health_check_matcher              = var.health_check_matcher
+  health_check_path                 = var.health_check_path
+  health_check_timeout              = var.health_check_timeout
+  health_check_healthy_threshold    = var.health_check_healthy_threshold
+  health_check_unhealthy_threshold  = var.health_check_unhealthy_threshold
+  health_check_interval             = var.health_check_interval
+  deregistration_delay              = var.deregistration_delay
+  target_type                       = "ip"
+  stickiness_enabled                = var.load_balancer_stickiness_enabled
+  stickiness_cookie_duration        = var.stickiness_cookie_duration
+  load_balancing_algorithm          = var.load_balancing_algorithm
+  load_balancing_anomaly_mitigation = var.load_balancing_anomaly_mitigation
 }
 
 resource "aws_ecs_service" "service" {
@@ -31,6 +33,9 @@ resource "aws_ecs_service" "service" {
   desired_count   = var.desired_count
 
   health_check_grace_period_seconds = var.health_check_grace_period_seconds
+
+  deployment_maximum_percent         = var.deployment_max_percent
+  deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
 
   load_balancer {
     target_group_arn = module.target.target_group_arn

--- a/tf/modules/ecs/web_fargate/variables.tf
+++ b/tf/modules/ecs/web_fargate/variables.tf
@@ -172,3 +172,23 @@ variable "stickiness_cookie_name" {
   description = "Name of the cookie used for stickiness. Only required for the app_cookie type"
   default     = ""
 }
+
+variable "deployment_max_percent" {
+  description = "Upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment"
+  default     = 200
+}
+
+variable "deployment_min_healthy_percent" {
+  description = "Lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment"
+  default     = 100
+}
+
+variable "load_balancing_algorithm" {
+  description = "Determines how the load balancer selects targets when routing requests"
+  default     = "round_robin"
+}
+
+variable "load_balancing_anomaly_mitigation" {
+  description = "Determines whether to enable target anomaly mitigation. Target anomaly mitigation is only supported if load_balancing_algorithm='weighted_random'"
+  default     = "off"
+}

--- a/tf/modules/load-balancing/target/main.tf
+++ b/tf/modules/load-balancing/target/main.tf
@@ -46,6 +46,9 @@ resource "aws_alb_target_group" "service" {
   deregistration_delay = var.deregistration_delay
   target_type          = var.target_type
 
+  load_balancing_algorithm_type     = var.load_balancing_algorithm
+  load_balancing_anomaly_mitigation = var.load_balancing_anomaly_mitigation
+
   dynamic "stickiness" {
     for_each = var.stickiness_enabled == false ? [] : [1]
     content {

--- a/tf/modules/load-balancing/target/readme.md
+++ b/tf/modules/load-balancing/target/readme.md
@@ -9,24 +9,30 @@ This module creates the following resources:
 
 ## Parameters
 
-| Name                             | Description                                                                      | Default       |
-|----------------------------------|----------------------------------------------------------------------------------|---------------|
-| name                             | Name of target group                                                             |               |
-| vpc                              | Id of the VPC that LB is in                                                      |               |
-| hostname                         | Optional hostname, prepended to `domain`, for `host_header` rule                 | ""            |
-| domain                           | Hostname for LB rule                                                             |               |
-| path_patterns                    | Path patterns to match in ALB                                                    | ["/*]         |
-| zone_id                          | HostedZone id for creating R53 rule. Required if `create_route_53_entry` is true | ""            |
-| create_route53_entry             | If true a Rotute53 alias record is created for listener                          | true          |
-| ip_whitelist                     | List of CIDR blocks to allow web access for                                      | ["0.0.0.0/0"] |
-| load_balancer_arn                | ARN of load balancer to add rule to                                              |               |
-| listener_arn                     | ARN of listener to attach to                                                     |               |
-| priority                         | Priority for listener arn                                                        |               |
-| health_check_matcher             | List of HTTP status codes for health check                                       | "200,404"     |
-| health_check_path                | Path to test HTTP status for health check                                        | "/"           |
-| health_check_timeout             | Timeout for health check (seconds)                                               | 10            |
-| health_check_healthy_threshold   | Threshold for number of healthy checks                                           | 2             |
-| health_check_unhealthy_threshold | Threshold for number of unhealthy checks                                         | 2             |
-| health_check_interval            | Interval between health checks (seconds)                                         | 30            |
-| deregistration_delay             | Target group deregistration delay (seconds)                                      | 30            |
-| target_type                      | TargetType for ELB TargetGroup                                                   | instance      |
+| Name                              | Description                                                                       | Default       |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------- |
+| name                              | Name of target group                                                              |               |
+| vpc                               | Id of the VPC that LB is in                                                       |               |
+| hostname                          | Optional hostname, prepended to `domain`, for `host_header` rule                  | ""            |
+| domain                            | Hostname for LB rule                                                              |               |
+| path_patterns                     | Path patterns to match in ALB                                                     | ["/*]         |
+| zone_id                           | HostedZone id for creating R53 rule. Required if `create_route_53_entry` is true  | ""            |
+| create_route53_entry              | If true a Rotute53 alias record is created for listener                           | true          |
+| ip_whitelist                      | List of CIDR blocks to allow web access for                                       | ["0.0.0.0/0"] |
+| load_balancer_arn                 | ARN of load balancer to add rule to                                               |               |
+| listener_arn                      | ARN of listener to attach to                                                      |               |
+| priority                          | Priority for listener arn                                                         |               |
+| health_check_matcher              | List of HTTP status codes for health check                                        | "200,404"     |
+| health_check_path                 | Path to test HTTP status for health check                                         | "/"           |
+| health_check_timeout              | Timeout for health check (seconds)                                                | 10            |
+| health_check_healthy_threshold    | Threshold for number of healthy checks                                            | 2             |
+| health_check_unhealthy_threshold  | Threshold for number of unhealthy checks                                          | 2             |
+| health_check_interval             | Interval between health checks (seconds)                                          | 30            |
+| deregistration_delay              | Target group deregistration delay (seconds)                                       | 30            |
+| target_type                       | TargetType for ELB TargetGroup                                                    | instance      |
+| stickiness_enabled                | Whether stickiness should be enabled or not                                       | false         |
+| stickiness_cookie_duration        | Duration of the stickiness cookie                                                 | 86400s        |
+| stickiness_type                   | The type of stickiness cookie                                                     | ""            |
+| stickiness_cookie_name            | Name of the cookie used for stickiness. Only required for the app_cookie type     | ""            |
+| load_balancing_algorithm          | Load balancer algorithm type                                                      | round_robin   |
+| load_balancing_anomaly_mitigation | Whether anomaly mitigation is on or off. Only valid for weighted_random algorithm | off           |

--- a/tf/modules/load-balancing/target/variables.tf
+++ b/tf/modules/load-balancing/target/variables.tf
@@ -8,7 +8,7 @@ variable "vpc" {
 
 variable "hostname" {
   description = "Optional hostname, prepended to domain, for host_header rule"
-  default = ""
+  default     = ""
 }
 
 variable "domain" {
@@ -99,13 +99,35 @@ variable "stickiness_enabled" {
 }
 
 variable "stickiness_cookie_duration" {
-  description = "duration of the stickiness cookie.  Only used in the lb_cookie type"
+  description = "Duration of the stickiness cookie.  Only used in the lb_cookie type"
+  default     = 86400 # 1 day
 }
 
 variable "stickiness_type" {
   description = "The type of stickiness cookie. Can be lb_cookie or app_cookie"
+  default     = ""
 }
 
 variable "stickiness_cookie_name" {
   description = "Name of the cookie used for stickiness. Only required for the app_cookie type"
+  default     = ""
+}
+
+variable "load_balancing_algorithm" {
+  description = "Determines how the load balancer selects targets when routing requests"
+  default     = "round_robin"
+  validation {
+    condition     = contains(["round_robin", "least_outstanding_requests", "weighted_random"], var.load_balancing_algorithm)
+    error_message = "load_balancing_algorithm must be 'round_robin', 'least_outstanding_requests' or 'weighted_random'"
+  }
+}
+
+variable "load_balancing_anomaly_mitigation" {
+  description = "Determines whether to enable target anomaly mitigation. Target anomaly mitigation is only supported if load_balancing_algorithm='weighted_random'"
+  default     = "off"
+
+  validation {
+    condition     = contains(["on", "off"], var.load_balancing_anomaly_mitigation)
+    error_message = "load_balancing_anomaly_mitigation must be 'on' or 'off'"
+  }
 }


### PR DESCRIPTION
Update `load-balancing/target` module to allow control of load-balancing algorithm being used. This is commonly used with `ecs/web_fargate` and `ecs/web_ec2` so exposed this control via those modules too.

Update `ecs/web_fargate` and `ecs/web_ec2` to allow control of maximum and minimum deployment percentages.