### PR TITLE
Add data modules for ALB and CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Create a EC2 host with EFS + EBS backed storage. Designed to be general-speciali
 
 Create a EC2 host with EFS + EBS backed storage
 
+## data
+
+Modules for AWS Athena / AWS Glue
+
+### alb
+
+Sets up AWS Glue table for ALB logs
+
+### cloudfront
+
+Sets up AWS Glue table for CloudFront logs
+
 ## ecs
 
 ECS specific modules (a number of the other, older, modules are ECS specific and should be removed).

--- a/changelog.md
+++ b/changelog.md
@@ -197,3 +197,7 @@ Update stickiness to allow for choosing whether to use `lb_cookie` or `app_cooki
 Allow deployment min/max percent to be set for ECS services in `ecs/web_fargate` and `ecs/web_ec2`.
 
 Allow load-balancing algorithm to be controlled in `load-balancing/target` (extended to `ecs/web_fargate` and `ecs/web_ec2`)
+
+## 3.31 2024-07-17
+
+Add `data/alb` and `data/cloudfront` modules.

--- a/tf/modules/data/alb/main.tf
+++ b/tf/modules/data/alb/main.tf
@@ -25,12 +25,6 @@ resource "aws_glue_catalog_table" "lb_logs" {
     input_format      = "org.apache.hadoop.mapred.TextInputFormat"
     output_format     = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
 
-    skewed_info {
-      skewed_column_names               = []
-      skewed_column_value_location_maps = {}
-      skewed_column_values              = []
-    }
-
     ser_de_info {
       serialization_library = "org.apache.hadoop.hive.serde2.RegexSerDe"
 

--- a/tf/modules/data/alb/main.tf
+++ b/tf/modules/data/alb/main.tf
@@ -1,0 +1,52 @@
+# Setup table for querying ELB logs. 
+# Based on: https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
+# NOTE - this was created via a query in Athena then imported
+resource "aws_glue_catalog_table" "lb_logs" {
+  name          = var.table_name
+  database_name = var.database_name
+  owner         = "hadoop"
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL                       = "TRUE"
+    "projection.enabled"           = "true"
+    "projection.day.type"          = "date"
+    "projection.day.range"         = "2024/01/01,NOW"
+    "projection.day.format"        = "yyyy/MM/dd"
+    "projection.day.interval"      = "1"
+    "projection.day.interval.unit" = "DAYS"
+    "storage.location.template"    = "${var.loadbalancer_logs_location}/$${day}"
+    "transient_lastDdlTime"        = "1717767997"
+  }
+
+  storage_descriptor {
+    location          = var.loadbalancer_logs_location
+    number_of_buckets = -1
+    input_format      = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format     = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    skewed_info {
+      skewed_column_names               = []
+      skewed_column_value_location_maps = {}
+      skewed_column_values              = []
+    }
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.RegexSerDe"
+
+      parameters = {
+        "input.regex" : "([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) ([^ ]*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\"($| \"[^ ]*\")(.*)"
+        "serialization.format" : "1"
+      }
+    }
+
+    dynamic "columns" {
+      for_each = local.alb_logs_table_columns
+      content {
+        name = columns.value.name
+        type = columns.value.type
+      }
+    }
+  }
+}
+

--- a/tf/modules/data/alb/readme.md
+++ b/tf/modules/data/alb/readme.md
@@ -1,0 +1,3 @@
+# ALB
+
+Create AWS Glue db table definition for ALB logs stored in S3.

--- a/tf/modules/data/alb/variables.tf
+++ b/tf/modules/data/alb/variables.tf
@@ -1,0 +1,133 @@
+locals {
+  alb_logs_table_columns = [
+    {
+      name = "type",
+      type = "string",
+    },
+    {
+      name = "time",
+      type = "string",
+    },
+    {
+      name = "elb",
+      type = "string",
+    },
+    {
+      name = "client_ip",
+      type = "string",
+    },
+    {
+      name = "client_port",
+      type = "int",
+    },
+    {
+      name = "target_ip",
+      type = "string",
+    },
+    {
+      name = "target_port",
+      type = "int",
+    },
+    {
+      name = "request_processing_time",
+      type = "double",
+    },
+    {
+      name = "target_processing_time",
+      type = "double",
+    },
+    {
+      name = "response_processing_time",
+      type = "double",
+    },
+    {
+      name = "elb_status_code",
+      type = "string",
+    },
+    {
+      name = "target_status_code",
+      type = "string",
+    },
+    {
+      name = "received_bytes",
+      type = "bigint",
+    },
+    {
+      name = "sent_bytes",
+      type = "bigint",
+    },
+    {
+      name = "request_verb",
+      type = "string",
+    },
+    {
+      name = "request_url",
+      type = "string",
+    },
+    {
+      name = "request_proto",
+      type = "string",
+    },
+    {
+      name = "user_agent",
+      type = "string",
+    },
+    {
+      name = "ssl_cipher",
+      type = "string",
+    },
+    {
+      name = "ssl_protocol",
+      type = "string",
+    },
+    {
+      name = "target_group_arn",
+      type = "string",
+    },
+    {
+      name = "trace_id",
+      type = "string",
+    },
+    {
+      name = "domain_name",
+      type = "string",
+    },
+    {
+      name = "chosen_cert_arn",
+      type = "string",
+    },
+    {
+      name = "matched_rule_priority",
+      type = "string",
+    },
+    {
+      name = "request_creation_time",
+      type = "string",
+    },
+    {
+      name = "actions_executed",
+      type = "string",
+    },
+    {
+      name = "redirect_url",
+      type = "string",
+    },
+    {
+      name = "new_field",
+      type = "string",
+    }
+  ]
+}
+
+variable "table_name" {
+  description = "Name to use for AWS Glue table"
+  default     = "lb_logs"
+}
+
+variable "database_name" {
+  description = "Name of the metadata database where the table metadata resides"
+}
+
+variable "loadbalancer_logs_location" {
+  description = "Full s3:// location where ALB logs are output to (without trailing slash)"
+}

--- a/tf/modules/data/cloudfront/main.tf
+++ b/tf/modules/data/cloudfront/main.tf
@@ -1,0 +1,35 @@
+# Setup table for querying Cloudwatch logs
+# Based on: https://docs.aws.amazon.com/athena/latest/ug/cloudfront-logs.html
+resource "aws_glue_catalog_table" "cloudfront_logs_catalog_table" {
+  name          = var.table_name
+  database_name = var.database_name
+
+  parameters = {
+    EXTERNAL                 = "TRUE"
+    "skip.header.line.count" = "2"
+  }
+
+  storage_descriptor {
+    location      = var.cloudfront_logs_location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      name                  = "serde"
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+
+      parameters = {
+        "field.delim" : "\t"
+        "serialization.format" : "\t"
+      }
+    }
+
+    dynamic "columns" {
+      for_each = local.cloudfront_logs_table_columns
+      content {
+        name = columns.value.name
+        type = columns.value.type
+      }
+    }
+  }
+}

--- a/tf/modules/data/cloudfront/readme.md
+++ b/tf/modules/data/cloudfront/readme.md
@@ -1,0 +1,3 @@
+# CloudFront
+
+Create AWS Glue db table definition for cloudfront logs stored in S3.

--- a/tf/modules/data/cloudfront/variables.tf
+++ b/tf/modules/data/cloudfront/variables.tf
@@ -1,0 +1,149 @@
+locals {
+  cloudfront_logs_table_columns = [
+    {
+      name = "date"
+      type = "date"
+    },
+    {
+      name = "time",
+      type = "string",
+    },
+    {
+      name = "location",
+      type = "string",
+    },
+    {
+      name = "bytes",
+      type = "bigint",
+    },
+    {
+      name = "request_ip",
+      type = "string",
+    },
+    {
+      name = "method",
+      type = "string",
+    },
+    {
+      name = "host",
+      type = "string",
+    },
+    {
+      name = "uri",
+      type = "string",
+    },
+    {
+      name = "status",
+      type = "int",
+    },
+    {
+      name = "referrer",
+      type = "string",
+    },
+    {
+      name = "user_agent",
+      type = "string",
+    },
+    {
+      name = "query_string",
+      type = "string",
+    },
+    {
+      name = "cookie",
+      type = "string",
+    },
+    {
+      name = "result_type",
+      type = "string",
+    },
+    {
+      name = "request_id",
+      type = "string",
+    },
+    {
+      name = "host_header",
+      type = "string",
+    },
+    {
+      name = "request_protocol",
+      type = "string",
+    },
+    {
+      name = "request_bytes",
+      type = "bigint",
+    },
+    {
+      name = "time_taken",
+      type = "float",
+    },
+    {
+      name = "xforwarded_for",
+      type = "string",
+    },
+    {
+      name = "ssl_protocol",
+      type = "string",
+    },
+    {
+      name = "ssl_cipher",
+      type = "string",
+    },
+    {
+      name = "response_result_type",
+      type = "string",
+    },
+    {
+      name = "http_version",
+      type = "string",
+    },
+    {
+      name = "fle_status",
+      type = "string",
+    },
+    {
+      name = "fle_encrypted_fields",
+      type = "int",
+    },
+    {
+      name = "c_port",
+      type = "int",
+    },
+    {
+      name = "time_to_first_byte",
+      type = "float",
+    },
+    {
+      name = "x_edge_detailed_result_type",
+      type = "string",
+    },
+    {
+      name = "sc_content_type",
+      type = "string",
+    },
+    {
+      name = "sc_content_len",
+      type = "bigint",
+    },
+    {
+      name = "sc_range_start",
+      type = "bigint",
+    },
+    {
+      name = "sc_range_end",
+      type = "bigint",
+    }
+  ]
+}
+
+variable "table_name" {
+  description = "Name to use for AWS Glue table"
+  default     = "cloudfront_logs"
+}
+
+variable "database_name" {
+  description = "Name of the metadata database where the table metadata resides"
+}
+
+variable "cloudfront_logs_location" {
+  description = "Full s3:// location where ALB logs are output to (without trailing slash)"
+}


### PR DESCRIPTION
New `data/` modules to help setting up AWS Glue tables for use with Athena.

Left out creation of Athena database / workgroup / s3 output location etc as there's little involved in that and keeps modules simple.