### PR TITLE
Changes to support disabling enabled stickiness

### DIFF
--- a/tf/modules/ecs/web_ec2/variables.tf
+++ b/tf/modules/ecs/web_ec2/variables.tf
@@ -144,7 +144,7 @@ variable "placement_constraints" {
 
 variable "load_balancer_stickiness_enabled" {
   description = "Whether stickiness should be enabled or not"
-  default     = null
+  default     = false
 }
 
 variable "stickiness_cookie_duration" {

--- a/tf/modules/ecs/web_ec2/variables.tf
+++ b/tf/modules/ecs/web_ec2/variables.tf
@@ -144,7 +144,7 @@ variable "placement_constraints" {
 
 variable "load_balancer_stickiness_enabled" {
   description = "Whether stickiness should be enabled or not"
-  default     = false
+  default     = null
 }
 
 variable "stickiness_cookie_duration" {
@@ -154,7 +154,7 @@ variable "stickiness_cookie_duration" {
 
 variable "stickiness_type" {
   description = "The type of stickiness cookie. Can be lb_cookie or app_cookie"
-  default     = ""
+  default     = "lb_cookie"
 }
 
 variable "stickiness_cookie_name" {

--- a/tf/modules/ecs/web_fargate/variables.tf
+++ b/tf/modules/ecs/web_fargate/variables.tf
@@ -165,7 +165,7 @@ variable "stickiness_cookie_duration" {
 
 variable "stickiness_type" {
   description = "The type of stickiness cookie. Can be lb_cookie or app_cookie"
-  default     = ""
+  default     = "lb_cookie"
 }
 
 variable "stickiness_cookie_name" {

--- a/tf/modules/load-balancing/target/main.tf
+++ b/tf/modules/load-balancing/target/main.tf
@@ -50,7 +50,7 @@ resource "aws_alb_target_group" "service" {
   load_balancing_anomaly_mitigation = var.load_balancing_anomaly_mitigation
 
   dynamic "stickiness" {
-    for_each = var.stickiness_enabled == false ? [] : [{}]
+    for_each = var.stickiness_enabled == null ? [] : [{}]
     content {
       enabled            = var.stickiness_enabled
       type               = var.stickiness_type

--- a/tf/modules/load-balancing/target/main.tf
+++ b/tf/modules/load-balancing/target/main.tf
@@ -50,7 +50,7 @@ resource "aws_alb_target_group" "service" {
   load_balancing_anomaly_mitigation = var.load_balancing_anomaly_mitigation
 
   dynamic "stickiness" {
-    for_each = var.stickiness_enabled == false ? [] : [1]
+    for_each = var.stickiness_enabled == false ? [] : [{}]
     content {
       enabled            = var.stickiness_enabled
       type               = var.stickiness_type

--- a/tf/modules/load-balancing/target/main.tf
+++ b/tf/modules/load-balancing/target/main.tf
@@ -49,14 +49,11 @@ resource "aws_alb_target_group" "service" {
   load_balancing_algorithm_type     = var.load_balancing_algorithm
   load_balancing_anomaly_mitigation = var.load_balancing_anomaly_mitigation
 
-  dynamic "stickiness" {
-    for_each = var.stickiness_enabled == null ? [] : [{}]
-    content {
+  stickiness {
       enabled            = var.stickiness_enabled
       type               = var.stickiness_type
       cookie_duration    = var.stickiness_cookie_duration
       cookie_name        = var.stickiness_cookie_name
-    }
   }
 
   health_check {

--- a/tf/modules/load-balancing/target/variables.tf
+++ b/tf/modules/load-balancing/target/variables.tf
@@ -95,7 +95,7 @@ variable "target_type" {
 
 variable "stickiness_enabled" {
   description = "Whether stickiness should be enabled or not"
-  default     = null
+  default     = false
 }
 
 variable "stickiness_cookie_duration" {

--- a/tf/modules/load-balancing/target/variables.tf
+++ b/tf/modules/load-balancing/target/variables.tf
@@ -95,7 +95,7 @@ variable "target_type" {
 
 variable "stickiness_enabled" {
   description = "Whether stickiness should be enabled or not"
-  default     = false
+  default     = null
 }
 
 variable "stickiness_cookie_duration" {
@@ -105,7 +105,7 @@ variable "stickiness_cookie_duration" {
 
 variable "stickiness_type" {
   description = "The type of stickiness cookie. Can be lb_cookie or app_cookie"
-  default     = ""
+  default     = "lb_cookie"
 }
 
 variable "stickiness_cookie_name" {


### PR DESCRIPTION
This sets null to be the default for stickiness so that it is ignored by default

The reason for this change is that by setting `stickiness_enabled` to `false`, the stickiness config was actually being ignored, rather than removed and required manual intervention to properly remove stickiness once enabled.

This PR essentially sets a default value for stickiness type and removes a dynamic block that was causing the issue.

This means that modules can be updated without changes being applied for stickiness, and that removing the stickiness block will cause stickiness to be disabled

