### PR TITLE
Updates for SecurityHub requirements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -209,3 +209,13 @@ Fix issue in  `load-balancing/target`, `ecs/web_fargate` and `ecs/web_ec2` that 
 ## 3.33 2024-08-16
 
 Add default_tags to ASG resources for `bastion`, same as was done for capacity-providers in v3.28
+
+## 3.34 2024-08-23
+
+Various updates, driven by changes to conform to SecurityHub standards:
+
+* `bastion` - add `associate_public_ip_address = true` to avoid confusion if new `vpc.map_public_ips_on_launch` is set to `false`
+* `ecs/container_definition` - added `read_only_filesystem` var
+* `load-balancing/wildcard-alb` - added `drop_invalid_headers` and `enable_deletion_protection` vars
+* `s3/ssl-only` - new module to generate bucket policy for denying non-SSL traffic _single resource only - generally not ideal but saves boiler plate_
+* `vpc` - module now accepts `map_public_ips_on_launch` to opt out of auto-assigning for public subnets

--- a/tf/modules/bastion/main.tf
+++ b/tf/modules/bastion/main.tf
@@ -79,12 +79,15 @@ resource "aws_launch_template" "bastion" {
     name = aws_iam_instance_profile.bastion.name
   }
 
-  key_name = var.key_name
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups = concat(
+      [aws_security_group.bastion.id],
+      var.additional_security_groups
+    )
+  }
 
-  vpc_security_group_ids = concat(
-    [aws_security_group.bastion.id],
-    var.additional_security_groups
-  )
+  key_name = var.key_name
 
   dynamic "tag_specifications" {
     for_each = {

--- a/tf/modules/ecs/container_definition/main.tf
+++ b/tf/modules/ecs/container_definition/main.tf
@@ -13,9 +13,10 @@ locals {
 
     memoryReservation = var.memory_reservation
 
-    environment = local.final_environment
-    secrets     = local.final_secrets
-    ulimits     = local.final_ulimits
+    environment      = local.final_environment
+    secrets          = local.final_secrets
+    ulimits          = local.final_ulimits
+    logConfiguration = local.filtered_log_configuration
 
     mountPoints  = var.mount_points
     portMappings = var.port_mappings
@@ -24,15 +25,11 @@ locals {
     dependsOn    = var.depends
     tags         = var.tags
     links        = var.links
+    volumesFrom  = var.volumes_from
 
-    volumesFrom = var.volumes_from
-
-    logConfiguration = local.filtered_log_configuration
-
-    systemControls = var.system_controls
-
-    repositoryCredentials = var.repository_credentials
-
-    resourceRequirements = var.resource_requirements
+    systemControls         = var.system_controls
+    readonlyRootFilesystem = var.read_only_filesystem
+    repositoryCredentials  = var.repository_credentials
+    resourceRequirements   = var.resource_requirements
   }
 }

--- a/tf/modules/ecs/container_definition/ulimits.tf
+++ b/tf/modules/ecs/container_definition/ulimits.tf
@@ -3,9 +3,9 @@ locals {
   sorted_ulimits_keys = sort(local.ulimits_keys)
 
   final_ulimits = [
-    for key in local.sorted_ulimits_keys : 
+    for key in local.sorted_ulimits_keys :
     {
-      name = key
+      name      = key
       softLimit = tonumber(split(":", lookup(var.ulimits, key))[0])
       hardLimit = tonumber(split(":", lookup(var.ulimits, key))[1])
     }

--- a/tf/modules/ecs/container_definition/variables.tf
+++ b/tf/modules/ecs/container_definition/variables.tf
@@ -21,6 +21,11 @@ variable "log_configuration" {
   default = null
 }
 
+variable "read_only_filesystem" {
+  description = "When this parameter is true, the container is given read-only access to its root file system."
+  default     = null
+}
+
 variable "mount_points" {
   type = list(object({
     containerPath = string
@@ -129,7 +134,7 @@ variable "repository_credentials" {
 }
 
 variable "links" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 

--- a/tf/modules/load-balancing/wildcard-alb/README.md
+++ b/tf/modules/load-balancing/wildcard-alb/README.md
@@ -3,17 +3,21 @@
 This module will provide an Application Load Balancer that specifically expects a wildcard certificate.
 
 ## Parameters
-| Name                   | Description                                         | Type   | Default                   |
-| ---------------------- | --------------------------------------------------- | ------ | ------------------------- |
-| prefix                 | Prefix for AWS resources                            | string |                           |
-| name                   | Suffix for load balancer appliance                  | string |                           |
-| subnets                | List of subnets to associate load balancer with     | list   |                           |
-| security_groups        | List of security groups to join                     | list   |                           |
-| certificate_arn        | ARN of wildcard SSL certificate to use              | string |                           |
-| elb_ssl_policy         | SSL policy to use on load balancer                  | string | ELBSecurityPolicy-2016-08 |
-| vpc                    | ID of the VPC that the load balancer is deployed in | string |                           |
-| ip_whitelist           | IP CIDR whitelist                                   | list   | 0.0.0.0/0                 |
-| redirect_http_to_https | Enable default behaviour to redirect http to https  | string | false                     |
+| Name                       | Description                                                                              | Type   | Default                   |
+| -------------------------- | ---------------------------------------------------------------------------------------- | ------ | ------------------------- |
+| prefix                     | Prefix for AWS resources                                                                 | string |                           |
+| name                       | Suffix for load balancer appliance                                                       | string |                           |
+| subnets                    | List of subnets to associate load balancer with                                          | list   |                           |
+| security_groups            | List of security groups to join                                                          | list   |                           |
+| certificate_arn            | ARN of wildcard SSL certificate to use                                                   | string |                           |
+| elb_ssl_policy             | SSL policy to use on load balancer                                                       | string | ELBSecurityPolicy-2016-08 |
+| vpc                        | ID of the VPC that the load balancer is deployed in                                      | string |                           |
+| ip_whitelist               | IP CIDR whitelist                                                                        | list   | 0.0.0.0/0                 |
+| redirect_http_to_https     | Enable default behaviour to redirect http to https                                       | string | false                     |
+| access_logs_bucket         | Name of bucket where access_logs will be stored (optional)                               | string |                           |
+| access_logs_prefix         | Prefix where access_logs will be stored (optional)                                       | string |                           |
+| drop_invalid_headers       | If `true` headers are dropped if they contain anything other than alphanumeric or hyphen | bool   |                           |
+| enable_deletion_protection | If `true` deletion of the load balancer will be disabled via the AWS API                 | bool   |                           |
 
 ## Outputs
 | Name                  | Description                                  |

--- a/tf/modules/load-balancing/wildcard-alb/main.tf
+++ b/tf/modules/load-balancing/wildcard-alb/main.tf
@@ -58,7 +58,9 @@ resource "aws_alb" "lb" {
     }
   }
 
-  idle_timeout = var.idle_timeout_seconds
+  idle_timeout               = var.idle_timeout_seconds
+  drop_invalid_header_fields = var.drop_invalid_headers
+  enable_deletion_protection = var.enable_deletion_protection
 }
 
 resource "aws_alb_target_group" "default" {

--- a/tf/modules/load-balancing/wildcard-alb/variables.tf
+++ b/tf/modules/load-balancing/wildcard-alb/variables.tf
@@ -61,3 +61,15 @@ variable "access_logs_prefix" {
   default     = null
   type        = string
 }
+
+variable "drop_invalid_headers" {
+  description = "Whether HTTP headers with header fields that are not valid are removed by the load balancer. ELB requires that message header names contain only alphanumeric characters and hyphens"
+  default     = null
+  type        = bool
+}
+
+variable "enable_deletion_protection" {
+  description = "If true, deletion of the load balancer will be disabled via the AWS API"
+  default     = null
+  type        = bool
+}

--- a/tf/modules/s3/ssl-only/main.tf
+++ b/tf/modules/s3/ssl-only/main.tf
@@ -1,0 +1,26 @@
+# See https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+    actions = [
+      "s3:*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "arn:aws:s3:::${var.bucket}",
+      "arn:aws:s3:::${var.bucket}/*",
+    ]
+  }
+}

--- a/tf/modules/s3/ssl-only/output.tf
+++ b/tf/modules/s3/ssl-only/output.tf
@@ -1,0 +1,3 @@
+output "ssl_only" {
+  value = data.aws_iam_policy_document.bucket_policy.json
+}

--- a/tf/modules/s3/ssl-only/variables.tf
+++ b/tf/modules/s3/ssl-only/variables.tf
@@ -1,0 +1,16 @@
+variable "bucket" {
+  description = "Id of bucket to apply policy too"
+  type        = string
+}
+
+variable "source_policy_documents" {
+  description = " List of IAM policy documents that are merged together into the exported document (see TF docs)"
+  default     = null
+  type        = list(string)
+}
+
+variable "override_policy_documents" {
+  description = " List of IAM policy documents that are merged together into the exported document (see TF docs)"
+  default     = null
+  type        = list(string)
+}

--- a/tf/modules/vpc/README.md
+++ b/tf/modules/vpc/README.md
@@ -3,20 +3,21 @@
 Provides a single VPC with default 3 public and private subnets. Also creates s3 + dynamoDB vpc endpoints
 
 ## Parameters
-| Parameter  | Description                         | Type   | Default     |
-|------------|-------------------------------------|--------|-------------|
-| name       | "Name" tag to apply to resources    | string |             |
-| vpc_name   | Name of VPC                         | string |             |
-| region     | AWS region                          | string |             |
-| cidr_block | VPC CIDR block                      | string | 10.0.0.0/16 |
+| Parameter                | Description                                                              | Type   | Default     |
+| ------------------------ | ------------------------------------------------------------------------ | ------ | ----------- |
+| name                     | "Name" tag to apply to resources                                         | string |             |
+| vpc_name                 | Name of VPC                                                              | string |             |
+| region                   | AWS region                                                               | string |             |
+| cidr_block               | VPC CIDR block                                                           | string | 10.0.0.0/16 |
+| map_public_ips_on_launch | If true instances launched in public subnet will have public ip assigned | string | true        |
 
 ## Outputs
-| Parameter              | Description                     | Type   |
-|------------------------|---------------------------------|--------|
-| vpc_id                 | ID of the created VPC           | string |
-| private_subnets        | IDs of the private subnets      | list   |
-| cidr_block_private     | CIDR block for private subnets  | string |
-| private_route_table_id | Private subnets routetable id   | string |
-| public_subnets         | IDs of the public subnets       | list   |
-| cidr_block_public      | CIRD block for public subnets   | string |
-| public_route_table_id  | Public subnets routetable id    | string |
+| Parameter              | Description                    | Type   |
+| ---------------------- | ------------------------------ | ------ |
+| vpc_id                 | ID of the created VPC          | string |
+| private_subnets        | IDs of the private subnets     | list   |
+| cidr_block_private     | CIDR block for private subnets | string |
+| private_route_table_id | Private subnets routetable id  | string |
+| public_subnets         | IDs of the public subnets      | list   |
+| cidr_block_public      | CIRD block for public subnets  | string |
+| public_route_table_id  | Public subnets routetable id   | string |

--- a/tf/modules/vpc/main.tf
+++ b/tf/modules/vpc/main.tf
@@ -1,4 +1,4 @@
-locals { 
+locals {
   vpc_name = var.name == "" ? var.vpc_name : replace(replace("${var.name}-${var.cidr_block}", "/", "-"), ".", "-")
 
   cidr_block_public  = cidrsubnet(var.cidr_block, 1, 0)
@@ -10,7 +10,8 @@ module "vpc" {
 
   name = local.vpc_name
 
-  cidr_block_vpc = var.cidr_block
+  cidr_block_vpc           = var.cidr_block
+  map_public_ips_on_launch = var.map_public_ips_on_launch
 
   public_az_count           = 3
   cidr_block_public         = local.cidr_block_public

--- a/tf/modules/vpc/public-igw/main.tf
+++ b/tf/modules/vpc/public-igw/main.tf
@@ -4,7 +4,8 @@ module "subnets" {
 
   vpc_id = var.vpc_id
 
-  map_public_ips_on_launch = "true"
+  map_public_ips_on_launch = var.map_public_ips_on_launch
+  availability             = "public"
 
   az_count = var.az_count
 

--- a/tf/modules/vpc/public-igw/variables.tf
+++ b/tf/modules/vpc/public-igw/variables.tf
@@ -3,3 +3,6 @@ variable "vpc_id" {}
 variable "cidr_block" {}
 variable "cidrsubnet_newbits" {}
 variable "az_count" {}
+variable "map_public_ips_on_launch" {
+    default = true
+}

--- a/tf/modules/vpc/public-private-igw/main.tf
+++ b/tf/modules/vpc/public-private-igw/main.tf
@@ -17,6 +17,8 @@ module "public_subnets" {
 
   cidr_block         = var.cidr_block_public
   cidrsubnet_newbits = var.cidrsubnet_newbits_public
+  
+  map_public_ips_on_launch = var.map_public_ips_on_launch
 
   az_count = var.public_az_count
 }

--- a/tf/modules/vpc/public-private-igw/variables.tf
+++ b/tf/modules/vpc/public-private-igw/variables.tf
@@ -18,3 +18,8 @@ variable "enable_dns_support" {
 variable "enable_dns_hostnames" {
   default = true
 }
+
+variable "map_public_ips_on_launch" {
+  description = "Whether to map public ips on instances launched in public subnets"
+  default     = true
+}

--- a/tf/modules/vpc/subnets/main.tf
+++ b/tf/modules/vpc/subnets/main.tf
@@ -1,7 +1,7 @@
 data "aws_availability_zones" "zones" {}
 
 locals {
-  availability = var.map_public_ips_on_launch ? "public" : "private"
+  availability = var.availability == "" ? var.map_public_ips_on_launch ? "public" : "private" : var.availability
 
   az_count = length(data.aws_availability_zones.zones.names)
   az_names = data.aws_availability_zones.zones.names

--- a/tf/modules/vpc/subnets/variables.tf
+++ b/tf/modules/vpc/subnets/variables.tf
@@ -10,3 +10,7 @@ variable "cidrsubnet_newbits" {}
 variable "map_public_ips_on_launch" {
   default = false
 }
+
+variable "availability" {
+  default = ""
+}

--- a/tf/modules/vpc/variables.tf
+++ b/tf/modules/vpc/variables.tf
@@ -16,3 +16,8 @@ variable "cidr_block" {
   description = "VPC CIDR block"
   default     = "10.0.0.0/16"
 }
+
+variable "map_public_ips_on_launch" {
+  description = "Whether to map public ips on instances launched in public subnets"
+  default     = true
+}


### PR DESCRIPTION
Various updates, driven by changes to conform to SecurityHub standards:

* `bastion` - add `associate_public_ip_address = true` to avoid confusion if new `vpc.map_public_ips_on_launch` is set to `false`
* `ecs/container_definition` - added `read_only_filesystem` var
* `load-balancing/wildcard-alb` - added `drop_invalid_headers` and `enable_deletion_protection` vars
* `s3/ssl-only` - new module to generate bucket policy for denying non-SSL traffic _single resource only - generally not ideal but saves boiler plate_
* `vpc` - module now accepts `map_public_ips_on_launch` to opt out of auto-assigning for public subnets