### PR TITLE
Allow setting the port for ALB health checks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -219,3 +219,7 @@ Various updates, driven by changes to conform to SecurityHub standards:
 * `load-balancing/wildcard-alb` - added `drop_invalid_headers` and `enable_deletion_protection` vars
 * `s3/ssl-only` - new module to generate bucket policy for denying non-SSL traffic _single resource only - generally not ideal but saves boiler plate_
 * `vpc` - module now accepts `map_public_ips_on_launch` to opt out of auto-assigning for public subnets
+
+## 3.35 2025-03-20
+
+`ecs/web_fargate` and `ecs/web_ec2` and `load-balancing/target` modules gain `health_check_port` var.

--- a/tf/modules/ecs/web_ec2/main.tf
+++ b/tf/modules/ecs/web_ec2/main.tf
@@ -18,6 +18,7 @@ module "target" {
   health_check_healthy_threshold    = var.health_check_healthy_threshold
   health_check_unhealthy_threshold  = var.health_check_unhealthy_threshold
   health_check_interval             = var.health_check_interval
+  health_check_port                 = var.health_check_port
   deregistration_delay              = var.deregistration_delay
   target_type                       = "instance"
   stickiness_enabled                = var.load_balancer_stickiness_enabled

--- a/tf/modules/ecs/web_ec2/variables.tf
+++ b/tf/modules/ecs/web_ec2/variables.tf
@@ -76,6 +76,11 @@ variable "health_check_matcher" {
   default     = "200,404"
 }
 
+variable "health_check_port" {
+  description = "Port to test HTTP status for health check"
+  default     = "traffic-port"
+}
+
 variable "health_check_path" {
   description = "Path to test HTTP status for health check"
   default     = "/"

--- a/tf/modules/ecs/web_fargate/main.tf
+++ b/tf/modules/ecs/web_fargate/main.tf
@@ -18,6 +18,7 @@ module "target" {
   health_check_healthy_threshold    = var.health_check_healthy_threshold
   health_check_unhealthy_threshold  = var.health_check_unhealthy_threshold
   health_check_interval             = var.health_check_interval
+  health_check_port                 = var.health_check_port
   deregistration_delay              = var.deregistration_delay
   target_type                       = "ip"
   stickiness_enabled                = var.load_balancer_stickiness_enabled

--- a/tf/modules/ecs/web_fargate/variables.tf
+++ b/tf/modules/ecs/web_fargate/variables.tf
@@ -81,6 +81,11 @@ variable "health_check_matcher" {
   default     = "200,404"
 }
 
+variable "health_check_port" {
+  description = "Port to test HTTP status for health check"
+  default     = "traffic-port"
+}
+
 variable "health_check_path" {
   description = "Path to test HTTP status for health check"
   default     = "/"

--- a/tf/modules/load-balancing/target/main.tf
+++ b/tf/modules/load-balancing/target/main.tf
@@ -63,6 +63,7 @@ resource "aws_alb_target_group" "service" {
     unhealthy_threshold = var.health_check_unhealthy_threshold
     interval            = var.health_check_interval
     matcher             = var.health_check_matcher
+    port                = var.health_check_port
   }
 }
 

--- a/tf/modules/load-balancing/target/variables.tf
+++ b/tf/modules/load-balancing/target/variables.tf
@@ -58,6 +58,11 @@ variable "health_check_matcher" {
   default     = "200,404"
 }
 
+variable "health_check_port" {
+  description = "Port to test HTTP status for health check"
+  default     = "traffic-port"
+}
+
 variable "health_check_path" {
   description = "Path to test HTTP status for health check"
   default     = "/"


### PR DESCRIPTION
Needed for the OTEL collector, which publishes its health check on a separate endpoint than is used for collection.