### PR TITLE
Add Load balancer client_keep_alive options with standard default

### DIFF
--- a/tf/modules/load-balancing/wildcard-alb/main.tf
+++ b/tf/modules/load-balancing/wildcard-alb/main.tf
@@ -58,9 +58,11 @@ resource "aws_alb" "lb" {
     }
   }
 
+  client_keep_alive          = var.client_keep_alive
   idle_timeout               = var.idle_timeout_seconds
   drop_invalid_header_fields = var.drop_invalid_headers
   enable_deletion_protection = var.enable_deletion_protection
+
 }
 
 resource "aws_alb_target_group" "default" {

--- a/tf/modules/load-balancing/wildcard-alb/variables.tf
+++ b/tf/modules/load-balancing/wildcard-alb/variables.tf
@@ -73,3 +73,9 @@ variable "enable_deletion_protection" {
   default     = null
   type        = bool
 }
+
+variable "client_keep_alive" {
+  description = "client keep alive value, in seconds. The valid range is 60-604800 seconds. The default is 3600 seconds"
+  default     = 3600
+  type        = number 
+}


### PR DESCRIPTION
Add option for client keep alive

Default set to standard 3600 seconds 

References

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#dns_record_client_routing_policy-1
- https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html


