### PR TITLE
Add additional_topic_names var to sqs module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -257,3 +257,9 @@ Allows control of [ecs_target > network_configuration](https://registry.terrafor
 ## 3.42 2025-12-17
 
 Add `data/waf` module for querying WAF logs via Athena.
+
+## 3.43 2026-05-01
+
+Add `additional_topic_names` var to `/messaging/sqs`. 
+
+This is optional and allows consumers to provide further topic names to subsribe to queue.

--- a/tf/modules/messaging/sqs/queue_policy.tf
+++ b/tf/modules/messaging/sqs/queue_policy.tf
@@ -20,9 +20,7 @@ data "aws_iam_policy_document" "sns_write_to_queue" {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
 
-      values = [
-        local.topic_arn
-      ]
+      values = local.all_topic_arns
     }
   }
 }

--- a/tf/modules/messaging/sqs/sns.tf
+++ b/tf/modules/messaging/sqs/sns.tf
@@ -6,3 +6,14 @@ resource "aws_sns_topic_subscription" "sns_topic" {
   filter_policy        = var.filter_policy
   filter_policy_scope  = var.filter_policy_scope
 }
+
+resource "aws_sns_topic_subscription" "additional_topics" {
+  for_each = toset(local.additional_topic_arns)
+
+  protocol             = "sqs"
+  topic_arn            = each.value
+  endpoint             = aws_sqs_queue.q.arn
+  raw_message_delivery = var.raw_message_delivery
+  filter_policy        = var.filter_policy
+  filter_policy_scope  = var.filter_policy_scope
+}

--- a/tf/modules/messaging/sqs/variables.tf
+++ b/tf/modules/messaging/sqs/variables.tf
@@ -1,5 +1,8 @@
 locals {
-  topic_arn = format("arn:aws:sns:%s:%s:%s", var.region, var.account_id, var.topic_name)
+  # Build topic ARNs from name to avoid dependency headaches
+  topic_arn             = format("arn:aws:sns:%s:%s:%s", var.region, var.account_id, var.topic_name)
+  additional_topic_arns = [for name in var.additional_topic_names : format("arn:aws:sns:%s:%s:%s", var.region, var.account_id, name)]
+  all_topic_arns        = concat([local.topic_arn], local.additional_topic_arns)
 }
 
 variable "queue_name" {
@@ -8,6 +11,12 @@ variable "queue_name" {
 
 variable "topic_name" {
   description = "Topic name for the SNS topic to subscribe the queue to"
+}
+
+variable "additional_topic_names" {
+  description = "Additional SNS topic names to also subscribe this queue to"
+  type        = list(string)
+  default     = []
 }
 
 variable "visibility_timeout_seconds" {


### PR DESCRIPTION
Allows additional topics to publish to the queue being created. Used a new variables rather than extending the existing property to avoid churn