### PR TITLE
Capacity Provider and Bastion default to AL2023

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -270,7 +270,7 @@ This is optional and allows consumers to provide further topic names to subsribe
 
 ## 3.45 2026-05-29
 
-`ecs/ec2_capacity_provider` and `ecs/ec2_capacity_provider_abs` default AMI updated to AmazonLinux 2023.
+`ecs/ec2_capacity_provider`, `ecs/ec2_capacity_provider_abs` and `bastion` default AMI updated to AmazonLinux 2023.
 
 Also changes from using `data "aws_ami"` to using `"resolve:ssm:*` style syntax. This means that on startup 
 the ASG will read the latest AMI from that location, there's no need to apply TF to update the latest image.

--- a/changelog.md
+++ b/changelog.md
@@ -267,3 +267,15 @@ This is optional and allows consumers to provide further topic names to subsribe
 ## 3.44 2026-05-12
 
 `ecs/ec2_capacity_provider` and `ecs/ec2_capacity_provider_abs` output ASG arn.
+
+## 3.45 2026-05-29
+
+`ecs/ec2_capacity_provider` and `ecs/ec2_capacity_provider_abs` default AMI updated to AmazonLinux 2023.
+
+Also changes from using `data "aws_ami"` to using `"resolve:ssm:*` style syntax. This means that on startup 
+the ASG will read the latest AMI from that location, there's no need to apply TF to update the latest image.
+
+> [!WARNING]
+> User-data may need changing as this uses AL2023 and previous used and AL2.
+>
+> https://docs.aws.amazon.com/AmazonECS/latest/developerguide/al2-to-al2023-ami-transition.html

--- a/changelog.md
+++ b/changelog.md
@@ -272,8 +272,12 @@ This is optional and allows consumers to provide further topic names to subsribe
 
 `ecs/ec2_capacity_provider`, `ecs/ec2_capacity_provider_abs` and `bastion` default AMI updated to AmazonLinux 2023.
 
-Also changes from using `data "aws_ami"` to using `"resolve:ssm:*` style syntax. This means that on startup 
-the ASG will read the latest AMI from that location, there's no need to apply TF to update the latest image.
+`ecs/ec2_capacity_provider` and `bastion` changes from using `data "aws_ami"` to using `"resolve:ssm:*` style syntax.
+This means that on startup the ASG will read the latest AMI from that location, there's no need to apply TF to update 
+the latest image.
+
+`ecs/ec2_capacity_provider_abs` continues to lookup AMI as it uses a `mixed_instances_policy`, this is a constraint
+of AWS as it needs to evaluate the AMI to find appropriate types so needs to know up front.
 
 > [!WARNING]
 > User-data may need changing as this uses AL2023 and previous used and AL2.

--- a/tf/modules/bastion/main.tf
+++ b/tf/modules/bastion/main.tf
@@ -73,7 +73,7 @@ resource "aws_iam_instance_profile" "bastion" {
 
 resource "aws_launch_template" "bastion" {
   name_prefix   = "${var.prefix}-bastion-"
-  image_id      = var.ami == null ? data.aws_ami.amazon_linux_2023.id : var.ami
+  image_id      = var.ami
   instance_type = var.instance_type
   iam_instance_profile {
     name = aws_iam_instance_profile.bastion.name
@@ -176,16 +176,6 @@ resource "aws_autoscaling_group" "bastion" {
     key                 = "Name"
     value               = "${var.prefix}-bastion"
     propagate_at_launch = true
-  }
-}
-
-data "aws_ami" "amazon_linux_2023" {
-  owners      = ["amazon"]
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["al2023-ami-2023.*-x86_64"]
   }
 }
 

--- a/tf/modules/bastion/variables.tf
+++ b/tf/modules/bastion/variables.tf
@@ -17,8 +17,8 @@ variable "instance_type" {
 }
 
 variable "ami" {
-  description = "AMI to use, defaults to latest amazon linux 2023 if not provided"
-  default     = null
+  description = "AMI ID to use for the bastion instance. Defaults to the latest Amazon Linux 2023 (x86_64) via SSM Parameter Store."
+  default     = "resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 }
 
 variable "key_name" {

--- a/tf/modules/ecs/ec2_capacity_provider/launch_template.tf
+++ b/tf/modules/ecs/ec2_capacity_provider/launch_template.tf
@@ -7,7 +7,7 @@ locals {
 resource "aws_launch_template" "launch_template" {
   name                   = "${var.name}_launch_template"
   instance_type          = var.instance_type
-  image_id               = var.ami_id == null ? data.aws_ami.ecs_optimized.id : var.ami_id
+  image_id               = var.ami_id
   vpc_security_group_ids = var.security_group_ids
   user_data              = base64encode(local.user_data)
   update_default_version = true
@@ -74,16 +74,6 @@ resource "aws_launch_template" "launch_template" {
       resource_type = tag_specifications.key
       tags          = tag_specifications.value.tags
     }
-  }
-}
-
-data "aws_ami" "ecs_optimized" {
-  owners      = ["amazon"]
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
   }
 }
 

--- a/tf/modules/ecs/ec2_capacity_provider/variables.tf
+++ b/tf/modules/ecs/ec2_capacity_provider/variables.tf
@@ -39,8 +39,9 @@ variable "assign_public_ips" {
 }
 
 variable "ami_id" {
-  type    = string
-  default = null // Uses the latest ECS-optimised AMI by default
+  description = "AMI ID to use for ECS instances. Defaults to the latest ECS-optimised Amazon Linux 2023 (x86_64) via SSM Parameter Store"
+  type        = string
+  default     = "resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
 }
 
 variable "root_size_gb" {
@@ -63,8 +64,8 @@ variable "data_size_gb" {
 
 variable "data_volume_type" {
   description = "Size of additional data volume, mounted as /dev/xvdf"
-  type    = string
-  default = "gp2"
+  type        = string
+  default     = "gp2"
 }
 
 variable "scaling_action_cooldown" {

--- a/tf/modules/ecs/ec2_capacity_provider_abs/launch_template.tf
+++ b/tf/modules/ecs/ec2_capacity_provider_abs/launch_template.tf
@@ -6,7 +6,7 @@ locals {
 
 resource "aws_launch_template" "launch_template" {
   name                   = "${var.name}_launch_template"
-  image_id               = var.ami_id == null ? data.aws_ami.ecs_optimized.id : var.ami_id
+  image_id               = var.ami_id
   vpc_security_group_ids = var.security_group_ids
   user_data              = base64encode(local.user_data)
   update_default_version = true
@@ -152,16 +152,6 @@ resource "aws_launch_template" "launch_template" {
       resource_type = tag_specifications.key
       tags          = tag_specifications.value.tags
     }
-  }
-}
-
-data "aws_ami" "ecs_optimized" {
-  owners      = ["amazon"]
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
   }
 }
 

--- a/tf/modules/ecs/ec2_capacity_provider_abs/launch_template.tf
+++ b/tf/modules/ecs/ec2_capacity_provider_abs/launch_template.tf
@@ -1,12 +1,18 @@
 data "aws_default_tags" "default_tags" {}
 
+data "aws_ssm_parameter" "ecs_ami" {
+  count = var.ami_id == "" ? 1 : 0
+  name  = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+}
+
 locals {
   asg_resources_to_tag = ["instance", "volume", "network-interface"]
+  resolved_ami_id      = var.ami_id != "" ? var.ami_id : data.aws_ssm_parameter.ecs_ami[0].value
 }
 
 resource "aws_launch_template" "launch_template" {
   name                   = "${var.name}_launch_template"
-  image_id               = var.ami_id
+  image_id               = local.resolved_ami_id
   vpc_security_group_ids = var.security_group_ids
   user_data              = base64encode(local.user_data)
   update_default_version = true

--- a/tf/modules/ecs/ec2_capacity_provider_abs/variables.tf
+++ b/tf/modules/ecs/ec2_capacity_provider_abs/variables.tf
@@ -42,8 +42,9 @@ variable "assign_public_ips" {
 }
 
 variable "ami_id" {
-  type    = string
-  default = null // Uses the latest ECS-optimised AMI by default
+  description = "AMI ID to use for ECS instances. Defaults to the latest ECS-optimised Amazon Linux 2023 (x86_64) via SSM Parameter Store"
+  type        = string
+  default     = "resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
 }
 
 variable "root_size_gb" {

--- a/tf/modules/ecs/ec2_capacity_provider_abs/variables.tf
+++ b/tf/modules/ecs/ec2_capacity_provider_abs/variables.tf
@@ -42,9 +42,9 @@ variable "assign_public_ips" {
 }
 
 variable "ami_id" {
-  description = "AMI ID to use for ECS instances. Defaults to the latest ECS-optimised Amazon Linux 2023 (x86_64) via SSM Parameter Store"
+  description = "AMI ID to use for ECS instances. Defaults to the latest ECS-optimised Amazon Linux 2023 (x86_64) via SSM Parameter Store lookup"
   type        = string
-  default     = "resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+  default     = ""
 }
 
 variable "root_size_gb" {


### PR DESCRIPTION
Default is to use `"resolve:"` syntax to resolve AMI, avoids churn and ensures we are always on latest. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-launch-template.html#use-an-ssm-parameter-instead-of-an-ami-id

capacity_provider_asg cannot use `"resolve:"` due to limitation in mixed instances policy.